### PR TITLE
minor tweak to filter issue

### DIFF
--- a/php/class-fm-bylines.php
+++ b/php/class-fm-bylines.php
@@ -681,7 +681,7 @@ if ( ! class_exists( 'FM_Bylines' ) ) {
 				$urls[] = $this->get_byline_link( $byline_id, $type );
 			}
 
-			echo $this->write_byline( $urls );
+			return $this->write_byline( $urls );
 		}
 
 		/**


### PR DESCRIPTION
This plugin adds a filter to `the_author_posts_link` but instead of returning the new link value, it simply echoes it and returns `'null` which means that (a) it trivially appears to work if it's the only filter, but (b) other filters can't override it.
